### PR TITLE
Check binary SID for emptiness

### DIFF
--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -57,6 +57,10 @@ class Utilities
      */
     public static function binarySidToString($value)
     {
+        if (empty($value)) {
+            return;
+        }
+
         // Revision - 8bit unsigned int (C1)
         // Count - 8bit unsigned int (C1)
         // 2 null bytes


### PR DESCRIPTION
We are getting "unpack(): Type C: not enough input, need 1, have 0" error when use adldap in our synchronization with ActiveDirectory.